### PR TITLE
fix up final link line

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,16 +3,18 @@ INC := $(wildcard include/*.c)
 OBJ_SRC := $(SRC:.c=.o)
 OBJ_INC := $(INC:.c=.o)
 
+LDLIBS := $(shell sdl2-config --cflags --libs) -lm
+
 all: build
 
 build: $(OBJ_SRC) $(OBJ_INC)
-	$(CC) -g $^ -o build `sdl2-config --cflags --libs`
+	$(CC) -g $^ -o build $(LDLIBS)
 
 src/%.o: src/%.c
-	$(CC) -c $< -o $@ `sdl2-config --cflags --libs`
+	$(CC) -c $< -o $@
 
 include/%.o: include/%.c
-	$(CC) -c $< -o $@ `sdl2-config --cflags --libs`
+	$(CC) -c $< -o $@
 
 clean:
 	rm -rf src/*.o include/*.o build


### PR DESCRIPTION
1. allow them to be controlled by users if they want via the "standard" LDLIBS variable
2. only provide them where really necessary (i.e. linking, not object compilation)
3. add -lm to avoid:

    cc -g src/main.o include/camera.o include/import_obj.o include/model.o include/render.o include/rotate.o include/transform.o include/vect.o -o build `sdl2-config --cflags --libs`
    /usr/bin/ld: include/vect.o: undefined reference to symbol 'sqrt@@GLIBC_2.2.5'
    /usr/bin/ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status
    make: *** [makefile:9: build] Error 1